### PR TITLE
Refactor Reddit pipeline for large array jobs

### DIFF
--- a/run_reddit_pipeline.sh
+++ b/run_reddit_pipeline.sh
@@ -4,9 +4,9 @@
 #SBATCH --error=logs/reddit_pipeline.%A_%a.err
 #SBATCH --time=24:00:00
 #SBATCH --mem=8G
-#SBATCH --cpus-per-task=64
+#SBATCH --cpus-per-task=1
 #SBATCH --nodes=1
-#SBATCH --array=0-7
+#SBATCH --array=0-255
 
 set -euxo pipefail
 

--- a/run_reddit_pipeline_test.sh
+++ b/run_reddit_pipeline_test.sh
@@ -4,7 +4,7 @@
 #SBATCH --error=logs/reddit_pipeline_test.%A_%a.err
 #SBATCH --time=02:00:00
 #SBATCH --mem=8G
-#SBATCH --cpus-per-task=16
+#SBATCH --cpus-per-task=1
 #SBATCH --nodes=1
 #SBATCH --array=0-0
 


### PR DESCRIPTION
## Summary
- distribute Reddit processing by chunk index so many 1‑CPU jobs can run in parallel
- append TSV results incrementally
- bump SLURM array in `run_reddit_pipeline.sh` to 256 tasks

## Testing
- `python -m py_compile process_reddit.py process_tusc.py helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68417d6df9b8832c9773b16b7fbcd1e2