### PR TITLE
Add precomputation for reddit line counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ bash download/download-reddit.sh
 # (2) Decompress the .zst archives (requires the zstd CLI)
 bash download/extract-data.sh
 #   ↳ produces RS_YYYY-MM.jsonl which are consumed by the pipeline
+
+# (optional) pre-compute line counts for faster repeated runs
+bash compute_linecounts.sh /path/to/reddit
 ```
 
 Tips:

--- a/compute_linecounts.sh
+++ b/compute_linecounts.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Compute line counts for reddit dataset files.
+# Usage: ./compute_linecounts.sh <data_dir>
+# Generates a file with suffix _linecount for each dataset file.
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <DATA_DIR>" >&2
+    exit 1
+fi
+
+DATA_DIR="$1"
+
+find "$DATA_DIR" -type f \( -name 'RS_*.jsonl' -o -name 'RC_*.jsonl' \) | while read -r file; do
+    count=$(wc -l < "$file")
+    echo "$count" > "${file}_linecount"
+    echo "${file}_linecount written with $count lines"
+done

--- a/process_reddit.py
+++ b/process_reddit.py
@@ -208,7 +208,15 @@ def main(
         # With chunked processing all tasks share the same list of files but
         # distribute chunks globally across tasks.
         for fp in files:
-            n_lines = count_lines(fp)
+            lc_path = f"{fp}_linecount"
+            if os.path.exists(lc_path):
+                try:
+                    with open(lc_path, "r") as lc_f:
+                        n_lines = int(lc_f.read().strip())
+                except Exception:
+                    n_lines = count_lines(fp)
+            else:
+                n_lines = count_lines(fp)
             line_counts[fp] = n_lines
             total_chunks += math.ceil(n_lines / chunk_size) if chunk_size else 1
         total_size_gb = sum(os.path.getsize(p) for p in files) / 1024 ** 3


### PR DESCRIPTION
## Summary
- add `compute_linecounts.sh` for generating `<file>_linecount` files
- read linecount files in `process_reddit.py` if present
- document optional precomputation step in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841abcf6c4c832ca991ad7f080090b1