### PR TITLE
Add PII post extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pyarrow>=20.0.0",
     "pytest-timeout>=2.4.0",
     "requests>=2.32.3",
+    "presidio-analyzer>=2.2.356",
     "spacy>=3.8.7",
     "tqdm>=4.67.1",
 ]

--- a/run_pii_pipeline.sh
+++ b/run_pii_pipeline.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Ensure logs directory exists
+mkdir -p logs
+
+echo "Submitting Reddit PII extraction job..."
+jobid_reddit=$(sbatch --parsable run_reddit_pii_pipeline.sh)
+
+echo "Submitting TUSC city PII extraction job..."
+jobid_city=$(INPUT_FILE="/beegfs/wahle/datasets/tusc/tusc-city.parquet" sbatch --parsable run_tusc_pii_pipeline.sh)
+
+echo "Submitting TUSC country PII extraction job..."
+jobid_country=$(INPUT_FILE="/beegfs/wahle/datasets/tusc/tusc-country.parquet" sbatch --parsable run_tusc_pii_pipeline.sh)
+
+echo ""
+echo "PII-only pipeline submitted successfully!"
+echo "============================================"
+echo "Reddit Job ID: $jobid_reddit"
+echo "TUSC City Job ID: $jobid_city"
+echo "TUSC Country Job ID: $jobid_country"
+echo ""
+echo "To check job status: squeue --user=\$USER"
+echo "To cancel jobs: scancel $jobid_reddit $jobid_city $jobid_country"
+echo "============================================"

--- a/run_reddit_pii_pipeline.sh
+++ b/run_reddit_pii_pipeline.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=reddit_pii
+#SBATCH --output=logs/reddit_pii.%A_%a.out
+#SBATCH --error=logs/reddit_pii.%A_%a.err
+#SBATCH --time=24:00:00
+#SBATCH --mem=8G
+#SBATCH --cpus-per-task=1
+#SBATCH --nodes=1
+#SBATCH --array=0-511
+
+set -euxo pipefail
+
+INPUT_DIR=/beegfs/wahle/datasets/reddit-2010-2022/extracted
+OUTPUT_DIR=/beegfs/wahle/github/abcde/outputs_reddit
+LINECOUNT_DIR=/beegfs/wahle/github/abcde/reddit_linecounts
+CHUNK_SIZE=${CHUNK_SIZE:-10000}
+
+export PYTHONUNBUFFERED=1
+
+uv run python process_reddit.py \
+    --input_dir "$INPUT_DIR" \
+    --output_dir "$OUTPUT_DIR" \
+    --workers "$SLURM_CPUS_PER_TASK" \
+    --chunk_size "$CHUNK_SIZE" \
+    --stages none \
+    --task_id "${SLURM_ARRAY_TASK_ID:-0}" \
+    --total_tasks "${SLURM_ARRAY_TASK_COUNT:-1}" \
+    --linecount_dir "$LINECOUNT_DIR" \
+    --collect_pii_posts

--- a/run_tusc_pii_pipeline.sh
+++ b/run_tusc_pii_pipeline.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=tusc_pii
+#SBATCH --output=logs/tusc_pii.%j.out
+#SBATCH --error=logs/tusc_pii.%j.err
+#SBATCH --time=24:00:00
+#SBATCH --mem=64GB
+
+set -euxo pipefail
+
+INPUT_FILE="${INPUT_FILE:-/beegfs/wahle/datasets/tusc/tusc-city.parquet}"
+OUTPUT_DIR="/beegfs/wahle/github/abcde/outputs_tusc"
+CHUNK_SIZE=${CHUNK_SIZE:-100000}
+
+export PYTHONUNBUFFERED=1
+
+uv run python process_tusc.py \
+    --input_file "$INPUT_FILE" \
+    --output_dir "$OUTPUT_DIR" \
+    --chunk_size "$CHUNK_SIZE" \
+    --stages none \
+    --collect_pii_posts


### PR DESCRIPTION
## Summary
- integrate Presidio to detect private info
- add private info extraction to reddit and TUSC pipelines
- expose new `--collect_pii_posts` option
- add slurm scripts for PII-only extraction
- lazily initialize self-ID detector and provide minimal lexicon for tests
- revert test modifications for FAST_TEST env var

## Testing
- `FAST_TEST=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854155b858c832c88a356e136456ac8